### PR TITLE
BE/feat/signup-api : 전역적 세팅 후 회원가입 API 구현

### DIFF
--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/controller/AuthController.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.scsa.outvite.auth.controller;
+
+import com.scsa.outvite.auth.dto.SignupResponse;
+import com.scsa.outvite.global.ApiResponse;
+import com.scsa.outvite.auth.dto.SignupRequest;
+import com.scsa.outvite.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ApiResponse signup(@RequestBody SignupRequest request) {
+        SignupResponse response = authService.signup(request);
+
+        return ApiResponse.builder()
+                .message("회원가입에 성공했습니다.")
+                .data(response)
+                .build();
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/dto/SignupRequest.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/dto/SignupRequest.java
@@ -1,0 +1,16 @@
+package com.scsa.outvite.auth.dto;
+
+import com.scsa.outvite.entity.Member;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class SignupRequest {
+    private String id;
+    private String password;
+    private String name;
+    private String phone;
+
+    public Member toEntity() {
+        return new Member(id, password, name, phone);
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/dto/SignupResponse.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/dto/SignupResponse.java
@@ -1,0 +1,17 @@
+package com.scsa.outvite.auth.dto;
+
+import com.scsa.outvite.entity.Member;
+import lombok.Getter;
+
+@Getter
+public class SignupResponse {
+    private String id;
+    private String name;
+    private String phone;
+
+    public SignupResponse(Member member) {
+        this.id = member.getId();
+        this.name = member.getName();
+        this.phone = member.getPhone();
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/error/AuthError.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/error/AuthError.java
@@ -1,0 +1,15 @@
+package com.scsa.outvite.auth.error;
+
+import com.scsa.outvite.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthError implements ErrorCode {
+    DUPLICATED_ID(HttpStatus.CONFLICT.value(), "사용할 수 없는 ID입니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/service/AuthService.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/auth/service/AuthService.java
@@ -1,0 +1,31 @@
+package com.scsa.outvite.auth.service;
+
+import com.scsa.outvite.auth.dto.SignupRequest;
+import com.scsa.outvite.auth.dto.SignupResponse;
+import com.scsa.outvite.entity.Member;
+import com.scsa.outvite.global.exception.BusinessException;
+import com.scsa.outvite.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.scsa.outvite.auth.error.AuthError.DUPLICATED_ID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest signupRequest) {
+        Member newMember = signupRequest.toEntity();
+
+        if (memberRepository.existsById(newMember.getId())) {
+            throw new BusinessException(DUPLICATED_ID);
+        }
+
+        memberRepository.save(newMember);
+
+        return new SignupResponse(newMember);
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/ApiResponse.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/ApiResponse.java
@@ -1,0 +1,14 @@
+package com.scsa.outvite.global;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ApiResponse {
+    @Builder.Default
+    private int status = HttpStatus.OK.value();
+    private String message;
+    private Object data;
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/AuthException.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.scsa.outvite.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private final int status;
+    private final String message;
+
+    public AuthException(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/BusinessException.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.scsa.outvite.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final int status;
+    private final String message;
+
+    public BusinessException(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/ErrorCode.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/ErrorCode.java
@@ -1,0 +1,7 @@
+package com.scsa.outvite.global.exception;
+
+public interface ErrorCode {
+    int getStatus();
+
+    String getMessage();
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/ErrorResponse.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.scsa.outvite.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String message;
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/GlobalExceptionHandler.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.scsa.outvite.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    //비즈니스 로직 예외 처리 -> BadRequest의 역할
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new ErrorResponse(e.getStatus(), e.getMessage()));
+    }
+
+    //인증 예외 처리 -> Unauthorized의 역할
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(AuthException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new ErrorResponse(e.getStatus(), e.getMessage()));
+    }
+
+    //그 외 모든 예외 처리 -> InternalServerError의 역할
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "unhandled exception"));
+    }
+}

--- a/dev/BE/outvite/src/main/java/com/scsa/outvite/repository/MemberRepository.java
+++ b/dev/BE/outvite/src/main/java/com/scsa/outvite/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.scsa.outvite.repository;
+
+import com.scsa.outvite.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, String> {
+    @Override
+    boolean existsById(String id);
+}


### PR DESCRIPTION
## 개요
#### ApiResponse
- status, message, data 의 응답 형식을 통일하기 위해 커스텀 했습니다.

#### Exception Setting
- GlobalExceptionHanler: RestControllerAdvice를 이용하여, Exception을 포착하도록 했습니다.
- Custom Exception
  - BusinessException(비즈니스 로직에서 충족되지 않은 요청에 대한 에러)
  - AuthException(인가되지 않은 요청에 대한 에러)

#### signup API
- 회원가입 API를 구현했습니다.
- 정상적으로 회원가입한 경우는 200 코드를 반환하고, id가 중복되는 경우에는 409코드를 반환합니다.
- [회원가입 API 명세](https://www.notion.so/812e86847ede4ee39c1e00521aee1084?pvs=4)

<!---- Resolves: #20 #22 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## Issue Closed
닫을 이슈 번호를 입력해주세요 (ex. close #22 #20)
